### PR TITLE
Issue #1 - add batrun subfits script for Orion support

### DIFF
--- a/batrun/subfits_orion_netcdf
+++ b/batrun/subfits_orion_netcdf
@@ -1,0 +1,76 @@
+set -euax
+
+EXPNAM=$1 CDATE=$2 COMROT=${3:-$STMP/$USER} ARCDIR=${4:-$COMROT/archive} TMPDIR=${5:-$STMP/$USER/tmpdir}
+
+ACCOUNT=${ACCOUNT:-CFS-T2O}
+CUE2RUN=${CUE2RUN:-dev}
+KEEPDATA=${KEEPDATA:-NO}
+
+vday=$(echo $CDATE | cut -c1-8)
+vcyc=$(echo $CDATE | cut -c9-10)
+
+echo -------------------------------------------------------------------------------------------------------------------
+echo Starting the runfits for:
+echo -------------------------------------------------------------------------------------------------------------------
+echo "EXPNAM    " $EXPNAM       # argument 1 - experiment name    - required  (can be prod in which case COMROT is moot)
+echo "CDATE     " $CDATE        # argument 2 - date of validation - required 
+echo "COMROT    " $COMROT       # argument 3 - COMROT directory   - optional - defaults to /stmp/$USER
+echo "ARCDIR    " $ARCDIR       # argument 4 - ARCDIR directory   - optional - defaults to $COMROT/archive 
+echo "TMPDIR    " $TMPDIR       # argument 5 - TMPDIR directory   - optional - defaults to /stmp/$USER/tmpdir
+echo "ACCOUNT   " $ACCOUNT      # inherited  - project code       - required - defaults to nothing  
+echo "KEEPDATA  " $KEEPDATA     # inherited  - retain rundir      - optional - defaults to NO (rmdir)
+echo -------------------------------------------------------------------------------------------------------------------
+
+fitdir=$(dirname $0); fitdir=$(cd $fitdir; pwd)
+COMDAY=${COMDAY:-$COMROT/logs/$CDATE}
+
+set -euax          
+
+vrfytmpdiris=$TMPDIR
+unset TMPDIR
+
+cat<<EOF | sbatch
+#!/bin/bash --login
+#SBATCH --job-name=FITS.$EXPNAM.$CDATE --time=20:00
+#SBATCH --nodes=1 --ntasks=3
+#SBATCH --output=$COMDAY/FITS.$EXPNAM.$CDATE.$$
+#SBATCH --account=$ACCOUNT
+#SBATCH --partition=debug
+#SBATCH -q debug
+
+#!/usr/bin/env bash
+set -euax
+
+set +x
+ module purge
+ module load intel/2020.2
+ module load impi/2020.2
+ module load netcdf/4.7.4
+ module list
+set -x
+
+export OMP_NUM_THREADS=${FITOMP:-1}
+export MPIRUN="srun --export=ALL -n 3"
+export KMP_AFFINITY=disabled
+
+export CDATE=$CDATE
+export EXP=$EXPNAM
+export COMPONENT=${COMPONENT:-atmos}
+export COM_IN=$ROTDIR
+export COM_INA=$ROTDIR/gdas.$vday/$vcyc/$COMPONENT
+export COM_INF='$ROTDIR/vrfyarch/gfs.\$fdy/\$fzz'
+export KEEPDATA=$KEEPDATA
+
+export RUN_ENVIR=netcdf     
+export CONVNETC=YES        
+export ACPROFit=YES  
+
+export fitdir=$fitdir
+export ARCDIR=$ARCDIR
+export TMPDIR=$vrfytmpdiris
+export PRVT=${PRVT:-$HOMEgfs/fix/fix_gsi/prepobs_errtable.global}
+export HYBLEVS=${HYBLEVS:-$HOMEgfs/fix/fix_am/global_hyblev.l65.txt}
+
+time $fitdir/runfits $EXPNAM $CDATE $COMROT
+
+EOF


### PR DESCRIPTION
Add batrun subfits script to add support for running Fit2Obs on Orion. Tested in C192C96L127 GFSv16 run on Orion. Jack reviewed logs and gave thumbs up.

This PR will close issue #1 