### PR TITLE
Add Jet Support

### DIFF
--- a/batrun/excfs_gdas_vrfyfits.sh.ecf
+++ b/batrun/excfs_gdas_vrfyfits.sh.ecf
@@ -55,15 +55,15 @@ eval COMPRP=$COM_PRP
 COMPRP=${COMPRP:-$COMLIC}
 set -u
 
-if [[ $RUN_ENVIR = nemsio || $RUN_ENVIR = netcdf ]] ; then
-  [[ $RUN_ENVIR = nemsio ]] && suffix=nemsio || suffix=nc
+if [[ $OUTPUT_FILETYPE = nemsio || $OUTPUT_FILETYPE = netcdf ]] ; then
+  [[ $OUTPUT_FILETYPE = nemsio ]] && suffix=nemsio || suffix=nc
   export PRPI=$COMPRP/gdas.t${hh}z.prepbufr
   export PRPO=$COMLOX/gdas.t${hh}z.prepqa
   export PRPF=$COMLOX/gdas.t${hh}z.prepqf
   export sig1=$COMLIC/gdas.t${hh}z.atmanl.$suffix
   export sfc1=$COMLIC/gdas.t${hh}z.atmanl.$suffix
   export CNVS=$COMLIC/gdas.t${hh}z.cnvstat
-elif [[ $RUN_ENVIR = cfs ]]; then
+elif [[ $OUTPUT_FILETYPE = cfs ]]; then
   tzz=t${hh}z
   export PRPI=$COMLIC/cdas1.$tzz.prepbufr       
   export PRPO=$COMOUT/cdas1.$tzz.prepqa           
@@ -72,7 +72,7 @@ elif [[ $RUN_ENVIR = cfs ]]; then
   export sfc1=$COMLIC/cdas1.$tzz.sfcanl 
   export CNVS=$COMLIC/cdas1.$tzz.cnvstat 
 else 
-  echo $RUN_ENVIR = unknown RUN_ENVIR; exit 999 
+  echo $OUTPUT_FILETYPE = unknown OUTPUT_FILETYPE; exit 999
 fi
 
 [ ${ACPROFit:-YES} != NO ] && PRPI=$($USHcfs/ACprof)
@@ -121,19 +121,19 @@ fdy=$(echo $FDATE|cut -c 1-8)
 fzz=$(echo $FDATE|cut -c 9-10)
 eval COMLICF=$COM_INF
 
-if [[ $RUN_ENVIR = nemsio || $RUN_ENVIR = netcdf ]] ; then
+if [[ $OUTPUT_FILETYPE = nemsio || $OUTPUT_FILETYPE = netcdf ]] ; then
   fhm3=$((fh-$tspan)); [ $fhm3 -lt 10 ] && fhm3=0$fhm3; [ $fhm3 -lt 100 ] && fhm3=0$fhm3
   fhp3=$((fh+$tspan)); [ $fhp3 -lt 10 ] && fhp3=0$fhp3; [ $fhp3 -lt 100 ] && fhp3=0$fhp3
   fh00=$fh;            [ $fh00 -lt 10 ] && fh00=0$fh00; [ $fh00 -lt 100 ] && fh00=0$fh00
   tzz=t$(echo $FDATE|cut -c9-10)z
-  [[ $RUN_ENVIR = nemsio ]] && suffix=nemsio || suffix=nc
+  [[ $OUTPUT_FILETYPE = nemsio ]] && suffix=nemsio || suffix=nc
   export sig1=$COMLICF/gfs.$tzz.atmf$fhm3.$suffix  
   export sig2=$COMLICF/gfs.$tzz.atmf$fh00.$suffix
   export sig3=$COMLICF/gfs.$tzz.atmf$fhp3.$suffix
   export sfc1=$COMLICF/gfs.$tzz.atmf$fhm3.$suffix
   export sfc2=$COMLICF/gfs.$tzz.atmf$fh00.$suffix
   export sfc3=$COMLICF/gfs.$tzz.atmf$fhp3.$suffix
-elif [[ $RUN_ENVIR = cfs ]]; then
+elif [[ $OUTPUT_FILETYPE = cfs ]]; then
   CDAM3=$($NDATE -$tspan  $CDATE)
   CDAP3=$($NDATE +$tspan  $CDATE)
   export sig1=$COMLICF/sigf${CDAM3}.01.$FDATE
@@ -143,7 +143,7 @@ elif [[ $RUN_ENVIR = cfs ]]; then
   export sfc2=$COMLICF/sfcf${CDATE}.01.$FDATE
   export sfc3=$COMLICF/sfcf${CDAP3}.01.$FDATE
 else 
-  echo $RUN_ENVIR = unknown RUN_ENVIR; exit 999 
+  echo $OUTPUT_FILETYPE = unknown OUTPUT_FILETYPE; exit 999
 fi
 
 if [ -s $sig1 -a -s $sig2 -a -s $sig3 ] ; then 

--- a/batrun/excfs_gdas_vrfyfits.sh.ecf
+++ b/batrun/excfs_gdas_vrfyfits.sh.ecf
@@ -1,4 +1,4 @@
-#!/bin/ksh
+#!/bin/bash
 #############################################################################
 # This script excfs_cdas_vrfyfits.sh.sms processes fits to obs
 # and generates the model verification statistis for CDAS/CFS
@@ -40,8 +40,7 @@ export PREC=$DATA/prec; echo  "&PREVDATA doanls=t,fits=t /" >$PREC
 #################################################################
 
 cd $DATA
-msg="JOB $job HAS BEGUN"
-postmsg "$jlogfile" "$msg"
+echo "JOB $job HAS BEGUN"
 
 # make bufr convdiag postevents for analysis only...
 fh1=06
@@ -195,8 +194,7 @@ cp -p $COMLOX/aircft.$typ.$CDATE       $HORZ_DIR/$typ/aircft.$CDATE
 done
 
 ################## END OF SCRIPT #######################
-msg='ENDED NORMALLY.'
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 cd $(dirname $DATA)
 if [ ${KEEPDATA:-"NO"} = "NO" ] ; then rm -rf $DATA ; fi
 ################## END OF SCRIPT #######################

--- a/batrun/runfits
+++ b/batrun/runfits
@@ -7,7 +7,7 @@ export EXECcfs=$HOMEcfs/exec
 export USHcfs=$HOMEcfs/ush 
 export NDATE=$EXECcfs/ndate
 
-export RUN_ENVIR=${RUN_ENVIR:-devpara}
+export OUTPUT_FILETYPE=${OUTPUT_FILETYPE:-netcdf}
 
 echo $ARCDIR                 ; mkdir -p $ARCDIR
 export FIT_DIR=$ARCDIR/fits  ; mkdir -p $FIT_DIR

--- a/batrun/runfits
+++ b/batrun/runfits
@@ -18,6 +18,6 @@ export COMLOX=$DATA/fitx; mkdir -p $COMLOX
 
 echo "echo err_chk">$DATA/err_chk; chmod 755 $DATA/err_chk
 echo "echo postmsg">$DATA/postmsg; chmod 755 $DATA/postmsg
-job=test; jlogfile=logfile
+job=test
 
 $fitdir/excfs_gdas_vrfyfits.sh.ecf     

--- a/batrun/subfits_dell_nems
+++ b/batrun/subfits_dell_nems
@@ -67,7 +67,7 @@ export COM_INA=$ROTDIR/gdas.$vday/$vcyc/$COMPONENT
 export COM_INF='$ROTDIR/vrfyarch/gfs.\$fdy/\$fzz'
 export KEEPDATA=$KEEPDATA
 
-export RUN_ENVIR=netcdf     
+export OUTPUT_FILETYPE=netcdf
 export CONVNETC=YES        
 export ACPROFit=YES  
 

--- a/batrun/subfits_jet
+++ b/batrun/subfits_jet
@@ -1,44 +1,42 @@
+#!/bin/bash
 set -euax
 
-EXPNAM=$1 CDATE=$2 COMROT=${3:-$STMP/$USER} ARCDIR=${4:-$COMROT/archive} TMPDIR=${5:-$STMP/$USER/tmpdir}
+EXPNAM=$1 CDATE=$2 ARCDIR=${ARCDIR:-$3} TMPDIR=${TMPDIR:-$4}
 
-ACCOUNT=${ACCOUNT:-CFS-T2O}
-CUE2RUN=${CUE2RUN:-dev}
-KEEPDATA=${KEEPDATA:-NO}
-PARTITION_BATCH=${PARTITION_BATCH:-xjet}
 
-vday=$(echo $CDATE | cut -c1-8)
-vcyc=$(echo $CDATE | cut -c9-10)
-
+set +x
 echo -------------------------------------------------------------------------------------------------------------------
-echo Starting the runfits for:
+echo Starting runfits: the following variables must be defined:
 echo -------------------------------------------------------------------------------------------------------------------
-echo "EXPNAM    " $EXPNAM       # argument 1 - experiment name    - required  (can be prod in which case COMROT is moot)
-echo "CDATE     " $CDATE        # argument 2 - date of validation - required 
-echo "COMROT    " $COMROT       # argument 3 - COMROT directory   - optional - defaults to /stmp/$USER
-echo "ARCDIR    " $ARCDIR       # argument 4 - ARCDIR directory   - optional - defaults to $COMROT/archive 
-echo "TMPDIR    " $TMPDIR       # argument 5 - TMPDIR directory   - optional - defaults to /stmp/$USER/tmpdir
-echo "ACCOUNT   " $ACCOUNT      # inherited  - project code       - required - defaults to nothing  
-echo "KEEPDATA  " $KEEPDATA     # inherited  - retain rundir      - optional - defaults to NO (rmdir)
+echo "EXPNAM    " $EXPNAM       # argument 1 - experiment name    - required
+echo "CDATE     " $CDATE        # argument 2 - date of validation - required
+echo "ARCDIR    " $ARCDIR       # argument 4 - ARCDIR directory   - optional - defaults to $COMROT/archive
+echo "TMPDIR    " $TMPDIR       # argument 5 - TMPDIR directory   - optional - defaults to /ptmp/$USER/tmpdir
+echo "ACCOUNT   " $ACCOUNT      # inherited  - project code       - required - defaults to nothing
+echo "COM_INA   " $COM_INA      # inheirited - project code       - required - defaults to nothing
+echo "COM_INF   " $COM_INF      # inheirited - project code       - required - defaults to nothing
+echo "OUTPUT_FILETYPE " $OUTPUT_FILETYPE    # inheirited - project code       - required - either nemsio or netcdf defaults to sigio
 echo -------------------------------------------------------------------------------------------------------------------
 
-fitdir=$(dirname $0); fitdir=$(cd $fitdir; pwd)
+fitdir=${fitdir:-$(dirname $0)}; fitdir=$(cd $fitdir; pwd)
 COMDAY=${COMDAY:-$COMROT/logs/$CDATE}
 
-set -euax          
+set -euax
 
 vrfytmpdiris=$TMPDIR
 unset TMPDIR
 
-cat<<EOF | sbatch
+cat<<eof | sbatch
 #!/bin/bash --login
-#SBATCH --job-name=FITS.$EXPNAM.$CDATE --time=20:00
-#SBATCH --nodes=1 --ntasks=3
-#SBATCH --output=$COMDAY/FITS.$EXPNAM.$CDATE.$$
+#SBATCH --job-name=FITS.$EXPNAM.$CDATE --time=00:20:00
+#SBATCH --nodes=3 --ntasks-per-node=1
+#SBATCH --output=$COMDAY/jet.fit2obs.log.$$
 #SBATCH --account=$ACCOUNT
+#SBATCH --qos=${CUE2RUN:-batch}
 #SBATCH --partition=$PARTITION_BATCH
 
-#!/usr/bin/env bash
+
+
 set -euax
 
 set +x
@@ -60,20 +58,14 @@ export CDATE=$CDATE
 export EXP=$EXPNAM
 export COMPONENT=${COMPONENT:-atmos}
 export COM_IN=$ROTDIR
-export COM_INA=$ROTDIR/gdas.$vday/$vcyc/$COMPONENT
-export COM_INF='$ROTDIR/vrfyarch/gfs.\$fdy/\$fzz'
 export KEEPDATA=$KEEPDATA
-
-export RUN_ENVIR=netcdf     
-export CONVNETC=YES        
-export ACPROFit=YES  
 
 export fitdir=$fitdir
 export ARCDIR=$ARCDIR
 export TMPDIR=$vrfytmpdiris
-export PRVT=${PRVT:-$HOMEgfs/fix/fix_gsi/prepobs_errtable.global}
-export HYBLEVS=${HYBLEVS:-$HOMEgfs/fix/fix_am/global_hyblev.l65.txt}
+export ACPROFit=${ACPROFit:-YES}
+export NEMS=${NEMS:-YES}
 
-time $fitdir/runfits $EXPNAM $CDATE $COMROT
+time $fitdir/runfits $EXPNAM $CDATE
 
-EOF
+eof

--- a/batrun/subfits_jet
+++ b/batrun/subfits_jet
@@ -51,7 +51,7 @@ set +x
 set -x
 
 export OMP_NUM_THREADS=${FITOMP:-1}
-export MPIRUN="srun --export=ALL -n 3"
+export MPIRUN="srun --export=ALL -n 3 --mem=0"
 export KMP_AFFINITY=disabled
 
 export CDATE=$CDATE

--- a/batrun/subfits_jet
+++ b/batrun/subfits_jet
@@ -1,0 +1,79 @@
+set -euax
+
+EXPNAM=$1 CDATE=$2 COMROT=${3:-$STMP/$USER} ARCDIR=${4:-$COMROT/archive} TMPDIR=${5:-$STMP/$USER/tmpdir}
+
+ACCOUNT=${ACCOUNT:-CFS-T2O}
+CUE2RUN=${CUE2RUN:-dev}
+KEEPDATA=${KEEPDATA:-NO}
+PARTITION_BATCH=${PARTITION_BATCH:-xjet}
+
+vday=$(echo $CDATE | cut -c1-8)
+vcyc=$(echo $CDATE | cut -c9-10)
+
+echo -------------------------------------------------------------------------------------------------------------------
+echo Starting the runfits for:
+echo -------------------------------------------------------------------------------------------------------------------
+echo "EXPNAM    " $EXPNAM       # argument 1 - experiment name    - required  (can be prod in which case COMROT is moot)
+echo "CDATE     " $CDATE        # argument 2 - date of validation - required 
+echo "COMROT    " $COMROT       # argument 3 - COMROT directory   - optional - defaults to /stmp/$USER
+echo "ARCDIR    " $ARCDIR       # argument 4 - ARCDIR directory   - optional - defaults to $COMROT/archive 
+echo "TMPDIR    " $TMPDIR       # argument 5 - TMPDIR directory   - optional - defaults to /stmp/$USER/tmpdir
+echo "ACCOUNT   " $ACCOUNT      # inherited  - project code       - required - defaults to nothing  
+echo "KEEPDATA  " $KEEPDATA     # inherited  - retain rundir      - optional - defaults to NO (rmdir)
+echo -------------------------------------------------------------------------------------------------------------------
+
+fitdir=$(dirname $0); fitdir=$(cd $fitdir; pwd)
+COMDAY=${COMDAY:-$COMROT/logs/$CDATE}
+
+set -euax          
+
+vrfytmpdiris=$TMPDIR
+unset TMPDIR
+
+cat<<EOF | sbatch
+#!/bin/bash --login
+#SBATCH --job-name=FITS.$EXPNAM.$CDATE --time=20:00
+#SBATCH --nodes=1 --ntasks=3
+#SBATCH --output=$COMDAY/FITS.$EXPNAM.$CDATE.$$
+#SBATCH --account=$ACCOUNT
+#SBATCH --partition=$PARTITION_BATCH
+
+#!/usr/bin/env bash
+set -euax
+
+set +x
+ module purge
+ module use /lfs4/HFIP/hfv3gfs/nwprod/hpc-stack/libs/modulefiles/stack
+ module load hpc/1.1.0
+ module load hpc-intel/18.0.5.274
+ module load hpc-impi/2018.4.274
+ module load hdf5/1.10.6
+ module load netcdf/4.7.4
+ module list
+set -x
+
+export OMP_NUM_THREADS=${FITOMP:-1}
+export MPIRUN="srun --export=ALL -n 3"
+export KMP_AFFINITY=disabled
+
+export CDATE=$CDATE
+export EXP=$EXPNAM
+export COMPONENT=${COMPONENT:-atmos}
+export COM_IN=$ROTDIR
+export COM_INA=$ROTDIR/gdas.$vday/$vcyc/$COMPONENT
+export COM_INF='$ROTDIR/vrfyarch/gfs.\$fdy/\$fzz'
+export KEEPDATA=$KEEPDATA
+
+export RUN_ENVIR=netcdf     
+export CONVNETC=YES        
+export ACPROFit=YES  
+
+export fitdir=$fitdir
+export ARCDIR=$ARCDIR
+export TMPDIR=$vrfytmpdiris
+export PRVT=${PRVT:-$HOMEgfs/fix/fix_gsi/prepobs_errtable.global}
+export HYBLEVS=${HYBLEVS:-$HOMEgfs/fix/fix_am/global_hyblev.l65.txt}
+
+time $fitdir/runfits $EXPNAM $CDATE $COMROT
+
+EOF

--- a/batrun/subfits_wcoss2
+++ b/batrun/subfits_wcoss2
@@ -18,7 +18,7 @@ echo "FITDIR    " $FITDIR       # inheirited - Fit2obs batrun dir - optional - d
 echo "ACCOUNT   " $ACCOUNT      # inheirited - project code       - required - defaults to nothing
 echo "COM_INA   " $COM_INA      # inheirited - project code       - required - defaults to nothing
 echo "COM_INF   " $COM_INF      # inheirited - project code       - required - defaults to nothing
-echo "RUN_ENVIR " $RUN_ENVIR    # inheirited - project code       - required - either nemsio or netcdf defaults to sigio
+echo "OUTPUT_FILETYPE " $OUTPUT_FILETYPE    # inheirited - project code       - required - either nemsio or netcdf defaults to sigio
 echo -------------------------------------------------------------------------------------------------------------------
 set -x
 

--- a/batrun/subfits_wcoss2
+++ b/batrun/subfits_wcoss2
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -eua
 
 EXPNAM=$1 CDATE=$2 ARCDIR=${ARCDIR:-$3} TMPDIR=${TMPDIR:-$4}
@@ -37,7 +37,6 @@ cat<<eof | qsub -
 #PBS -j oe
 #PBS -V       
 
-#!/usr/bin/env bash
 set -euax  
 
 CDATE=$CDATE
@@ -45,7 +44,7 @@ CDATE=$CDATE
 cd $PWD
 
 set +x
-module purge
+module reset
 module load envvar/1.0
 module load PrgEnv-intel/8.1.0
 module load craype/2.7.8

--- a/runs/rundell.cfs
+++ b/runs/rundell.cfs
@@ -4,7 +4,7 @@ export date=$1; pdy=$(echo $date|cut -c 1-8)
 
 export CUE2RUN=dev2
 
-export RUN_ENVIR=cfs    
+export OUTPUT_FILETYPE=cfs
 
 export ACCOUNT=CFS-T2O
 

--- a/runs/rundell.v15
+++ b/runs/rundell.v15
@@ -20,7 +20,7 @@ export ARCDIR=/gpfs/dell2/emc/verification/noscrub/Jack.Woollen/Fit2Obs/runs/arc
 export COM_INA=/gpfs/dell1/nco/ops/com/gfs/prod/gdas.$day/$our   
 export COM_INF='/gpfs/dell1/nco/ops/com/gfs/prod/gfs.$fdy/$fzz'  
 
-export RUN_ENVIR=nemsio 
+export OUTPUT_FILETYPE=nemsio
 export CONVNETC=NO 
 
 FITDIR=/gpfs/dell2/emc/verification/noscrub/Jack.Woollen/Fit2Obs           

--- a/runs/rundell.v16
+++ b/runs/rundell.v16
@@ -15,7 +15,7 @@ export ARCDIR=/gpfs/dell2/ptmp/Jack.Woollen/gdas/archive/v16
 
 export COMDAY=$PWD/outputs; mkdir -p $COMDAY
 
-export RUN_ENVIR=netcdf 
+export OUTPUT_FILETYPE=netcdf
 export EXPNAM=v16rt2c
 export CONVNETC=YES
 export ROTDIRS=/gpfs/dell3/ptmp/emc.glopara/ROTDIRS

--- a/runs/runhera
+++ b/runs/runhera
@@ -12,7 +12,7 @@ export ACCOUNT=fv3-cpu
 export COMDAY=$PWD/outputs; mkdir -p $COMDAY
 
 export COMPONENT=${COMPONENT:-atmos}
-export RUN_ENVIR=netcdf 
+export OUTPUT_FILETYPE=netcdf
 export CONVNETC=YES
 
 export ROTDIR=/scratch1/NCEPDEV/stmp4/Kate.Friedman/comrot/devv16cyc192b

--- a/runs/runorio.v15
+++ b/runs/runorio.v15
@@ -14,7 +14,7 @@ export COMDAY=$PWD/outputs; mkdir -p $COMDAY
 export COM_INA='/work/noaa/da/jwoollen/v15ics'
 export COM_INF='/dev/null'  
 
-export RUN_ENVIR=nemsio 
+export OUTPUT_FILETYPE=nemsio
 export CONVNETC=NO 
 
 export HYBLEVS=$PWD/global_hyblev.l65.txt

--- a/runs/runorio.v16
+++ b/runs/runorio.v16
@@ -14,7 +14,7 @@ export COMDAY=$PWD/outputs; mkdir -p $COMDAY
 export COM_INA='/work/noaa/da/jwoollen/ics'
 export COM_INF='/dev/null'  
 
-export RUN_ENVIR=netcdf 
+export OUTPUT_FILETYPE=netcdf
 export CONVNETC=YES
 
 export FITDIR=$(dirname $PWD)

--- a/runs/runorion
+++ b/runs/runorion
@@ -13,7 +13,7 @@ export ACCOUNT=fv3-cpu
 export COMDAY=$PWD/outputs; mkdir -p $COMDAY
 
 export COMPONENT=${COMPONENT:-atmos}
-export RUN_ENVIR=netcdf 
+export OUTPUT_FILETYPE=netcdf
 export CONVNETC=YES
 
 export ROTDIR=/work/noaa/stmp/lgan/comrot/naf19296       

--- a/runs/subfits_dell
+++ b/runs/subfits_dell
@@ -23,7 +23,7 @@ echo "FITDIR    " $FITDIR       # inheirited - Fit2obs batrun dir - optional - d
 echo "ACCOUNT   " $ACCOUNT      # inheirited - project code       - required - defaults to nothing
 echo "COM_INA   " $COM_INA      # inheirited - project code       - required - defaults to nothing
 echo "COM_INF   " $COM_INF      # inheirited - project code       - required - defaults to nothing
-echo "RUN_ENVIR " $RUN_ENVIR    # inheirited - project code       - required - either nemsio or netcdf defaults to sigio
+echo "OUTPUT_FILETYPE " $OUTPUT_FILETYPE    # inheirited - project code       - required - either nemsio or netcdf defaults to sigio
 echo -------------------------------------------------------------------------------------------------------------------
 set -x
 

--- a/runs/subfits_orio
+++ b/runs/subfits_orio
@@ -23,7 +23,7 @@ echo "FITDIR    " $FITDIR       # inheirited - Fit2obs batrun dir - optional - d
 echo "ACCOUNT   " $ACCOUNT      # inheirited - project code       - required - defaults to nothing
 echo "COM_INA   " $COM_INA      # inheirited - project code       - required - defaults to nothing
 echo "COM_INF   " $COM_INF      # inheirited - project code       - required - defaults to nothing
-echo "RUN_ENVIR " $RUN_ENVIR    # inheirited - project code       - required - either nemsio or netcdf defaults to sigio
+echo "OUTPUT_FILETYPE " $OUTPUT_FILETYPE    # inheirited - project code       - required - either nemsio or netcdf defaults to sigio
 echo -------------------------------------------------------------------------------------------------------------------
 set -x
 

--- a/runs/wcoss2.driver
+++ b/runs/wcoss2.driver
@@ -16,7 +16,7 @@ export COM_PRP='$OBSDIR/gdas.$pdy/$cyc/atmos'
 export COM_INA='$ROTDIR/gdas.$pdy/$cyc/atmos'
 export COM_INF='$ROTDIR/vrfyarch/gfs.$fdy/$fzz'
 
-export RUN_ENVIR=netcdf
+export OUTPUT_FILETYPE=netcdf
 export ACPROFit=YES
 export CONVNETC=YES
 

--- a/sorc/makes
+++ b/sorc/makes
@@ -5,7 +5,7 @@ plat=$1; mkdir -p ../exec
 
 if [ $# -lt 1 ]; then
     echo '***ERROR*** must specify machine'
-    echo ' Syntax: makes ( cray | dell | theia )'
+    echo ' Syntax: makes ( cray | dell | theia | wcoss2 | jet )'
     exit 1
 fi
 
@@ -43,6 +43,30 @@ elif [ $plat = hera ]; then
  export NETCDF_LDFLAGS="-L$NETCDF/lib -lnetcdff" 
  export NEMSIO_LIB=$nemsio_ROOT/lib64/libnemsio.a
  set +x
+elif [ $plat = jet ] ; then
+ module use /lfs4/HFIP/hfv3gfs/role.epic/hpc-stack/libs/intel-18.0.5.274/modulefiles/stack
+ module load hpc/1.2.0
+ module load hpc-intel/18.0.5.274
+ module load hpc-impi/2018.4.274
+ module load hdf5/1.10.6
+ module load netcdf/4.7.4
+ module load bacio/2.4.1
+ module load bufr/11.5.0
+ module load nemsio/2.5.2
+ module load sfcio/1.4.1
+ module load sigio/2.3.2
+ module load sp/2.3.3
+ module load w3emc/2.7.3
+ module load w3nco/2.4.1
+ module load zlib/1.2.11
+ export NETCDF_INCLUDE="-I $NETCDF/include"
+ export SIGIO_LIB4=$SIGIO_LIB
+ export SFCIO_LIB4=$SFCIO_LIB
+ export SIGIO_INC4=$SIGIO_INC
+ export SFCIO_INC4=$SFCIO_INC
+ export NETCDF_LDFLAGS="-L $NETCDF/lib -L $HDF5_LIBRARIES -lnetcdff -lnetcdf -lhdf5hl_fortran -lhdf5_hl -lhdf5 -lz"
+ export FLAGS="-O3 -g -traceback -axSSE4.2,AVX,CORE-AVX2"
+ export FCMP="mpiifort"
 elif [ $plat = dell ] ; then
  module purge
  module load EnvVars/1.0.3

--- a/ush/cfs_bufr_post.sh
+++ b/ush/cfs_bufr_post.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -eua
 #
 #   This script originally written by Jack Woollen

--- a/ush/cfs_cdas_fits.sh
+++ b/ush/cfs_cdas_fits.sh
@@ -1,4 +1,4 @@
-#!/bin/ksh
+#!/bin/bash
 if [ $# -ne 6 ] ; then
   echo "Usage: $0 CDATE (yyyymmddhh) PRPO COMOUT DATA fh1 fh2"
   exit 1

--- a/ush/cfs_cdas_horizn.sh
+++ b/ush/cfs_cdas_horizn.sh
@@ -1,4 +1,4 @@
-#!/bin/ksh
+#!/bin/bash
 set -xeua
 if [ $# -ne 5 ] ; then
   echo "Usage: $0 date (yyyymmddhh) prepqm outdir prtdir typ"

--- a/ush/cfs_cmon.sh
+++ b/ush/cfs_cmon.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 if [ $# -ne 1 ] ; then
 	echo "Usage: $0 MM|mmm"

--- a/ush/cfs_combfr.sh
+++ b/ush/cfs_combfr.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ####  UNIX Script Documentation Block
 #                .           .                                       .
 # Script name:   combfr      Combine blocked BUFR files

--- a/ush/cfs_horizn.sh
+++ b/ush/cfs_horizn.sh
@@ -1,4 +1,4 @@
-#!/bin/ksh
+#!/bin/bash
 if [ $# -ne 9 ] ; then
   echo "Usage: $0 oname nst iall imas iwnd fchr fdhr dtg sfc"
   exit 1

--- a/ush/cfs_prevmpi.sh
+++ b/ush/cfs_prevmpi.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 ###########################################################################
 #
 # This script encodes the background (first guess) and observational


### PR DESCRIPTION
Adds a subfits script for Jet and build instructions to the makes script for Jet.

This PR also brings in some script changes to match up new variable names in the global workflow and converts scripts to bash from sh and ksh.  These latter changes were made by @KateFriedman-NOAA and required to test the build on Jet.  If necessary, I can resubmit this PR with just the new build scripts.

Fixes #5