### PR TITLE
Update modulepath on Hera following rocky8 upgrade. Use  bufr 11.7.0 instead of 12.0.1

### DIFF
--- a/modulefiles/fit2obs_common.lua
+++ b/modulefiles/fit2obs_common.lua
@@ -10,7 +10,7 @@ local libpng_ver=os.getenv("libpng_ver") or "1.6.37"
 local netcdf_c_ver=os.getenv("netcdf_c_ver") or "4.9.2"
 local netcdf_fortran_ver=os.getenv("netcdf_fortran_ver") or "4.6.1"
 
-local bufr_ver=os.getenv("bufr_ver") or "12.0.1"
+local bufr_ver=os.getenv("bufr_ver") or "11.7.0"
 local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 local w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
 local sp_ver=os.getenv("sp_ver") or "2.5.0"

--- a/modulefiles/fit2obs_hera.intel.lua
+++ b/modulefiles/fit2obs_hera.intel.lua
@@ -2,7 +2,6 @@ help([[
 Build environment for fit2obs on Hera
 ]])
 
---prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
 prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"

--- a/modulefiles/fit2obs_hera.intel.lua
+++ b/modulefiles/fit2obs_hera.intel.lua
@@ -2,7 +2,8 @@ help([[
 Build environment for fit2obs on Hera
 ]])
 
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
+--prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"


### PR DESCRIPTION
Closes #18 
bufr 12.0.1 is not available on Hera/Rocky 8.