### PR TITLE
Migrate to Rocky8 spack stack 1.6.0 on Jet

### DIFF
--- a/modulefiles/fit2obs_jet.lua
+++ b/modulefiles/fit2obs_jet.lua
@@ -2,7 +2,7 @@ help([[
 Build environment for fit2obs on Jet
 ]])
 
-prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"


### PR DESCRIPTION
# Description
- Update Jet module file to use Rocky8 installation of spack-stack;
- Jet has been upgraded to the Rocky8 Linux OS and present module file no longer works
  Resolves #21
  Refs NOAA-EMC/global-workflow#2377

This change affects only Jet.

# How has this been tested?
Cycled Globla workflow experiments (48+ hours) on Jet at resolutions
- [x] 96/48 on xjet and kjet
- [x] 192/96 on kjet
- [x] 384/192 on kjet
