### PR TITLE
Update spack-stack env in fit2obs_hercules.lua

### DIFF
--- a/modulefiles/fit2obs_hercules.lua
+++ b/modulefiles/fit2obs_hercules.lua
@@ -2,7 +2,7 @@ help([[
 Build environment for fit2obs on Hercules
 ]])
 
-prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.9.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.9.0"


### PR DESCRIPTION
Fix `MODULEPATH` for Hercules to use the `gsi-addon-env`. Successfully built PR branch on Hercules with fix.

Will recut `wflow.1.1.4` tag after this PR is merged.

Resolves #30