### PR TITLE
Update cloud to spack-stack 1.9.2

### DIFF
--- a/modulefiles/fit2obs_noaacloud.lua
+++ b/modulefiles/fit2obs_noaacloud.lua
@@ -2,15 +2,16 @@ help([[
 Build environment for fit2obs on NOAA cloud
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", os.getenv("spack_stack_mod_path"))
 
-local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
-local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.10.0"
-
-load("gnu")
-load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("gnu", gcc_ver))
+load(pathJoin("stack-oneapi", stack_oneapi_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
 
 load("fit2obs_common")
+
+setenv("CC","/apps/oneapi/mpi/latest/bin/mpiicc")
+setenv("CXX","/apps/oneapi/mpi/latest/bin/mpiicpc")
+setenv("FC","/apps/oneapi/mpi/latest/bin/mpiifort")
 
 whatis("Description: fit2obs environment on NOAA cloud")

--- a/versions/noaacloud.ver
+++ b/versions/noaacloud.ver
@@ -1,4 +1,4 @@
 export gcc_ver=13.2.0
 export stack_oneapi_ver=2024.2.1
 export stack_intel_oneapi_mpi_ver=2021.13
-export spack_stack_mod_path="/contrib/spack-stack-rocky8/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core"
+export spack_stack_mod_path="/contrib/spack-stack-rocky8/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core"

--- a/versions/noaacloud.ver
+++ b/versions/noaacloud.ver
@@ -1,0 +1,4 @@
+export gcc_ver=13.2.0
+export stack_oneapi_ver=2024.2.1
+export stack_intel_oneapi_mpi_ver=2021.13
+export spack_stack_mod_path="/contrib/spack-stack-rocky8/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core"


### PR DESCRIPTION
This PR updates the cloud module and version files to build and run with spack-stack 1.9.2. 

I tested the build by setting `INSTALL_PREFIX` and running `ush/build.sh`, and the build was successful with no new errors or warnings.

Resolves #45 